### PR TITLE
fix(tui): restore backspace in AgentURL (eval field 0)

### DIFF
--- a/packages/tui/internal/tui/eval_form_controller.go
+++ b/packages/tui/internal/tui/eval_form_controller.go
@@ -97,17 +97,17 @@ func (m Model) handleEvalFormInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 
 	case "backspace":
 		// Handle backspace for text fields
-		if m.evalState.currentField > 0 {
+		if m.evalState.currentField >= 0 {
 			switch m.evalState.currentField {
 			case 0: // AgentURL
 				runes := []rune(m.evalState.AgentURL)
-				if m.evalState.cursorPos <= len(runes) {
+				if m.evalState.cursorPos > 0 && m.evalState.cursorPos <= len(runes) && len(runes) > 0 {
 					m.evalState.AgentURL = string(runes[:m.evalState.cursorPos-1]) + string(runes[m.evalState.cursorPos:])
 					m.evalState.cursorPos--
 				}
 			case 3: // JudgeModel
 				runes := []rune(m.evalState.JudgeModel)
-				if m.evalState.cursorPos <= len(runes) {
+				if m.evalState.cursorPos > 0 && m.evalState.cursorPos <= len(runes) && len(runes) > 0 {
 					m.evalState.JudgeModel = string(runes[:m.evalState.cursorPos-1]) + string(runes[m.evalState.cursorPos:])
 					m.evalState.cursorPos--
 				}


### PR DESCRIPTION
## Description
Restores backspace functionality in the `AgentURL` field on the New Evaluation form




## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

Modified the guard condition in the backspace handler within **handleEvalFormInput** function in `eval_form_controller.go`



## Related Issues/PRs

<!-- Link to related issues or PRs -->

- Fixes #125 